### PR TITLE
Fix missing RSS meta information

### DIFF
--- a/src/feed.njk
+++ b/src/feed.njk
@@ -4,19 +4,19 @@ eleventyExcludeFromCollections: true
 ---
 <?xml version="1.0" encoding="utf-8"?>
 <feed xmlns="http://www.w3.org/2005/Atom">
-    <title>{{ meta.title }}</title>
-    <subtitle>{{ meta.description }}</subtitle>
-    <link href="{{ meta.url }}/feed.xml" rel="self" type="application/atom+xml" />
-    <link href="{{ meta.url }}" rel="alternate" type="text/html"/>
+    <title>{{ site.title }}</title>
+    <subtitle>{{ site.description }}</subtitle>
+    <link href="{{ site.url }}/feed.xml" rel="self" type="application/atom+xml" />
+    <link href="{{ site.url }}" rel="alternate" type="text/html"/>
     <author>
-        <name>{{ meta.title }}</name>
+        <name>{{ author.name }}</name>
     </author>
     {% if collections.posts %}
     <updated>{{ collections.posts | rssLastUpdatedDate }}</updated>
     {% endif %}
-    <id>{{ meta.url }}/</id>
+    <id>{{ site.url }}/</id>
     {%- for post in collections.posts | reverse -%}
-    {% set absolutePostUrl %}{{ post.url | url | absoluteUrl(meta.url) }}{% endset %}
+    {% set absolutePostUrl %}{{ post.url | url | absoluteUrl(site.url) }}{% endset %}
         <entry>
             <title>{{ post.data.title }}</title>
             <link href="{{ absolutePostUrl }}"/>


### PR DESCRIPTION
Hey,

Love the site (and the content is wonderful too 👍).

I'm making an RSS reader/parser/doom scroller and noticed your RSS feed is missing some attributes. It looks like a file got renamed somewhere (`meta` -> `site`). I'm a fan of 11ty, so managed to find the missing info.

**Current RSS validation:**  😔

https://validator.w3.org/feed/check.cgi?url=https%3A%2F%2Fmxb.dev%2Ffeed.xml

**RSS based on this commit:** 🎉

![RSS passing validation](https://user-images.githubusercontent.com/354085/103573586-692d4e00-4ec6-11eb-96c3-cbf5d7466a6b.png)
