### PR TITLE
fix post edit link

### DIFF
--- a/src/layouts/post.njk
+++ b/src/layouts/post.njk
@@ -69,7 +69,7 @@ layout: base
         {% else %}
             <p class="post__footer-info">
                 Published in [{{ tags | join(', ') }}] &middot; {{ page.date | readableDate('dd LLL yyyy') }} <br/>
-                <a href="{{ site.repo }}/tree/master/{{ page.inputPath }}" title="suggest a change to this post by submitting a PR">Edit this Post</a>
+                <a href="{{ site.repo }}/tree/main/{{ page.inputPath }}" title="suggest a change to this post by submitting a PR">Edit this Post</a>
             </p>
 
             <a


### PR DESCRIPTION
The edit link in posts still links to master branch even though it does not exist and you use main as your main (I guess) branch.